### PR TITLE
feat: add paho-mqtt to docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -132,7 +132,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name == 'develop' && 'develop' || format('dev-{0}', github.ref_name) }}
 
-      - name: Build and push Docker image (Production Release)
+      - name: Build and push Docker image (Development Release)
         id: build-and-push
         uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
     py3-lxml \
     python3-dev
 
-
+RUN pip install --no-cache-dir --prefix=/install paho-mqtt
 RUN pip install --no-cache-dir --prefix=/install callattendant@git+https://github.com/thess/callattendant@v2.1.0
 
 FROM python:3.13.2-alpine3.21


### PR DESCRIPTION
This adds `paho-mqtt` to the base python install, and resolves #36 